### PR TITLE
Updated /submit-puzzle and /register-solved-puzzle to connect better with db

### DIFF
--- a/app/static/solvePuzzle.js
+++ b/app/static/solvePuzzle.js
@@ -365,7 +365,6 @@ function submitPuzzle() {
             },
             body: JSON.stringify({puzzleSize: puzzleSize,
                 puzzleId: requestedPuzzle.puzzleid,
-                userId: 1,
                 accuracy: Math.floor(Math.random() * 100) + 1,
                 shadedCells: shadedCells
             })


### PR DESCRIPTION
/submit-puzzle now correctly sets creator-id of submitted puzzle based on currently signed in user. (Previous behaviour: creator-id was set to null.)
/register-solved-puzzle now correctly gives the points from the puzzle to the currently signed in user. (Previous behaviour: always gave points to user 1.)

Also added @login_required to those two routes to prevent error from occurring when no users are in the database and someone wants to register a solved puzzle.